### PR TITLE
Treat host argument as string, not regex

### DIFF
--- a/inventory.js
+++ b/inventory.js
@@ -127,7 +127,7 @@ Inventory.prototype.removeHost = function removeHost(host)
 		var section = self.contents[self.secmap[k]];
 		section.items = section.items.filter(function(i)
 		{
-			return !i.match(host);
+			return i !== host;
 		});
 	});
 };


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Avoid RegEx Injection by treating host command-line argument as a string, not a regex

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Closes https://github.com/npm/dirac/security/code-scanning/1